### PR TITLE
Remove deedName(), change visibility of ownerOf() and countOfDeeds()

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -71,12 +71,12 @@ interface ERC721 {
     ///  queries about them do throw.
     /// @return The non-zero address of the owner of deed `_deedId`, or `throw`
     ///  if deed `_deedId` is not tracked by this contract
-    function ownerOf(uint256 _deedId) external view returns (address _owner);
+    function ownerOf(uint256 _deedId) public view returns (address _owner);
 
     /// @notice Count deeds tracked by this contract
     /// @return A count of valid deeds tracked by this contract, where each one of
     ///  them has an assigned and queryable owner not equal to the zero address
-    function countOfDeeds() external view returns (uint256 _count);
+    function countOfDeeds() public view returns (uint256 _count);
 
     /// @notice Count all deeds assigned to an owner
     /// @dev Throws if `_owner` is the zero address, representing invalid deeds.

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -155,10 +155,6 @@ interface ERC721Metadata {
     /// @dev Wallets and exchanges MAY display this to the end user.
     function symbol() public pure returns (string _symbol);
 
-    /// @notice A distinct name for a deed managed by this contract
-    /// @dev Wallets and exchanges MAY display this to the end user.
-    function deedName(uint256 _deedId) public pure returns (string _deedName);
-
     /// @notice A distinct URI (RFC 3986) for a given token.
     /// @dev If:
     ///  * The URI is a URL


### PR DESCRIPTION
deedName() data should be removed entirely or considered optional as not all deeds will have distinct names, even when ERC721Metadata is inherited. Collection name and symbol are important information, but everything about a specific deed should be optional and returned from deedURI data.

This function seems like an unnecessary and potentially confusing overlap/double-up of data that can already be part of deedUri() return data.